### PR TITLE
Update workflow to py3.10

### DIFF
--- a/.github/workflows/schematic-schema-convert.yml
+++ b/.github/workflows/schematic-schema-convert.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pip python3.8-venv libcurl4-openssl-dev
+          sudo apt-get install -y pip python3.10-venv libcurl4-openssl-dev
       
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This is to allow us to upgrade to the latest pypi release of schematic (23.6.3, previously was stuck to 23.1.1 due to python 3.8)