### PR TITLE
Fix PR creation: use GITHUB_TOKEN with peter-evans action

### DIFF
--- a/.github/workflows/mine-pubmed-nf.yml
+++ b/.github/workflows/mine-pubmed-nf.yml
@@ -134,8 +134,6 @@ jobs:
             - Filtered for Journal Article type only (exact match)
             - Filtered for free full text availability
             - Ready for review and Synapse upload
-
-            Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
           branch: pubmed-mining-${{ github.run_number }}
           delete-branch: true
           title: "📚 PubMed Mining Results - ${{ steps.mining.outputs.pub_count }} NF Publications"


### PR DESCRIPTION
- Switch from manual git/gh CLI to peter-evans/create-pull-request@v7
- Use GITHUB_TOKEN instead of PAT to avoid nfosi-service permission issues
- GITHUB_TOKEN can trigger upsert workflow on PR merge (separate event)
- Remove persist-credentials: false from checkout step

This resolves the 403 permission denied error when pushing branches.