### PR TITLE
Add MS03 NF2-deficient mouse Schwann cell line

### DIFF
--- a/submissions/cell_lines/MS03.json
+++ b/submissions/cell_lines/MS03.json
@@ -6,7 +6,7 @@
       "_doi": "10.1371/journal.pone.0197350",
       "_publicationTitle": "Traditional and systems biology based drug discovery for the rare tumor syndrome neurofibromatosis type 2",
       "_year": "2018",
-      "_usageType": "Model Development",
+      "_usageType": "Development",
       "_context": "First description of the MS03 NF2-deficient mouse Schwann cell line. MS03 carries a homozygous deletion of Nf2 exon 2 (Nf2ex2-/-) derived from dorsal root ganglia of PostnCre;Nf2flox/flox mice via Cre-lox recombination. Developed as part of the CTF Synodos for NF2 drug discovery program."
     }
   ],

--- a/submissions/cell_lines/accepted/MS03.json
+++ b/submissions/cell_lines/accepted/MS03.json
@@ -1,0 +1,36 @@
+{
+  "_source": "manual_curation",
+  "_publications": [
+    {
+      "_pmid": "PMID:29897904",
+      "_doi": "10.1371/journal.pone.0197350",
+      "_publicationTitle": "Traditional and systems biology based drug discovery for the rare tumor syndrome neurofibromatosis type 2",
+      "_year": "2018",
+      "_usageType": "Model Development",
+      "_context": "First description of the MS03 NF2-deficient mouse Schwann cell line. MS03 carries a homozygous deletion of Nf2 exon 2 (Nf2ex2-/-) derived from dorsal root ganglia of PostnCre;Nf2flox/flox mice via Cre-lox recombination. Developed as part of the CTF Synodos for NF2 drug discovery program."
+    }
+  ],
+  "_confidence": "1.0",
+  "_verdict": "Accept",
+  "toolType": "cell_line",
+  "userInfo": {},
+  "basicInfo": {
+    "cellLineName": "MS03",
+    "description": "Merlin-null (Nf2ex2-/-) mouse Schwann cell line derived from dorsal root ganglia of PostnCre;Nf2flox/flox mice via Cre-lox recombination. Developed by the CTF Synodos for NF2 Consortium.",
+    "synonyms": "",
+    "species": "Mouse",
+    "developerName": "Synodos for NF2 Consortium",
+    "developerAffiliation": "Children's Tumor Foundation"
+  },
+  "cellLineGeneticDisorder": "Neurofibromatosis Type 2",
+  "cellLineManifestation": "Schwannoma",
+  "cellLineCategory": "Transformed cell line",
+  "organ": "Peripheral Nervous System",
+  "tissue": "Dorsal Root Ganglion",
+  "sex": "Unknown",
+  "contaminatedMisidentified": "No",
+  "originYear": 2018,
+  "developmentPublicationDOI": "10.1371/journal.pone.0197350",
+  "usagePublicationDOIs": [],
+  "itemAcquisition": "Contact Developer"
+}


### PR DESCRIPTION
## Summary

Adds the MS03 cell line to the tools database, requested in nf-osi/nadia#186.

**MS03** is a merlin-null (*Nf2*ex2-/-) mouse Schwann cell line derived from dorsal root ganglia of *PostnCre;Nf2*flox/flox mice via Cre-lox recombination. It was developed by the CTF Synodos for NF2 Consortium and first described in:

> Synodos for NF2 Consortium (2018). Traditional and systems biology based drug discovery for the rare tumor syndrome neurofibromatosis type 2. *PLoS ONE*. DOI: [10.1371/journal.pone.0197350](https://doi.org/10.1371/journal.pone.0197350) (PMID: 29897904)

## Changes

- Adds `submissions/cell_lines/accepted/MS03.json`

| Field | Value |
|-------|-------|
| Cell line name | MS03 |
| Species | Mouse |
| Genetic disorder | Neurofibromatosis Type 2 |
| Manifestation | Schwannoma |
| Tissue | Dorsal Root Ganglion |
| Organ | Peripheral Nervous System |
| Genotype | *Nf2*ex2-/- (merlin-null) |
| Developer | Synodos for NF2 Consortium (CTF) |
| Dev publication | 10.1371/journal.pone.0197350 |

## Review notes

- `cellLineCategory` is set to "Transformed cell line" — *Nf2* loss (merlin loss) is the driver of transformation in schwannomas; the exact immortalization method is not specified in the development paper. Please update if a more precise category is known.
- `sex` is set to "Unknown" — not specified in development paper or associated datasets.