### PR TITLE
Replace 'Advanced Cellular Model' with 'Organoid Protocol' in submission form

### DIFF
--- a/NF-Tools-Schemas/organoid-protocol/submitOrganoidProtocol.json
+++ b/NF-Tools-Schemas/organoid-protocol/submitOrganoidProtocol.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Submit Advanced Cellular Model",
+  "title": "Submit Organoid Protocol",
   "type": "object",
   "properties": {
     "basicInfo": {
       "type": "object",
-      "title": "Advanced Cellular Model Information",
+      "title": "Organoid Protocol Information",
       "properties": {
-        "resourceName": { "type": "string", "title": "Name of Advanced Cellular Model" },
+        "resourceName": { "type": "string", "title": "Name of Organoid Protocol" },
         "synonyms": { "type": "string", "title": "Synonyms" },
         "description": { "type": "string", "title": "Description (~20-50 words)" },
         "modelType": {
@@ -198,7 +198,7 @@
       "description": "Your email address for follow-up questions about this submission.",
       "format": "email"
     },
-    "resourceType": { "type": "string", "title": "Resource Type", "default": "Advanced Cellular Model" }
+    "resourceType": { "type": "string", "title": "Resource Type", "default": "Organoid Protocol" }
   },
   "required": ["basicInfo", "itemAcquisition"],
   "allOf": [


### PR DESCRIPTION
## Summary
- Updates `submitAdvancedCellularModel.json` to replace all user-facing references to "Advanced Cellular Model" with "Organoid Protocol":
  - Form title: "Submit Organoid Protocol"
  - Section heading: "Organoid Protocol Information"
  - Field label: "Name of Organoid Protocol"
  - `resourceType` default value: "Organoid Protocol"

Companion to #142 (file/directory rename) and Sage-Bionetworks/synapse-web-monorepo#2720 (portal category rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)