### PR TITLE
Add Ptpn11E76K/+ murine JMML model

### DIFF
--- a/submissions/animal_models/Ptpn11_E76K_het_JMML.json
+++ b/submissions/animal_models/Ptpn11_E76K_het_JMML.json
@@ -1,0 +1,37 @@
+{
+  "_source": "manual_curation",
+  "_publications": [
+    {
+      "_pmid": "PMID:36739480",
+      "_doi": "10.3389/fonc.2023.1052930",
+      "_publicationTitle": "Potential clinical use of azacitidine and MEK inhibitor combination therapy in PTPN11-mutated juvenile myelomonocytic leukemia",
+      "_year": "2023",
+      "_usageType": "Experimental Usage",
+      "_context": "Shp2 E76K/+ murine model used to evaluate azacitidine + PD-901 (MEK inhibitor) combination therapy for PTPN11-mutated JMML. RNA-seq data deposited in GEO GSE211278 (Synapse syn74607259)."
+    }
+  ],
+  "_confidence": "0.9",
+  "_verdict": "Accept",
+  "toolType": "animal_model",
+  "userInfo": {},
+  "basicInfo": {
+    "animalModelName": "Ptpn11E76K/+",
+    "description": "Heterozygous Ptpn11 E76K germline knock-in mouse model of juvenile myelomonocytic leukemia (JMML). Encodes a gain-of-function SHP2 E76K variant that hyperactivates the Ras/MAPK pathway, recapitulating PTPN11-mutated JMML.",
+    "synonyms": "Shp2E76K/+; Ptpn11E76K/+; SHP2 E76K/+",
+    "species": "Mouse"
+  },
+  "strainNomenclature": "Ptpn11E76K/+",
+  "backgroundStrain": "C57BL/6",
+  "backgroundSubstrain": "",
+  "animalModelDisease": "Juvenile myelomonocytic leukemia",
+  "animalModelManifestation": "JMML",
+  "transplantationType": "",
+  "animalState": "",
+  "generation": "",
+  "alleleType": "Knock-in",
+  "affectedGeneSymbol": "Ptpn11",
+  "mutationTypes": "Gain-of-function point mutation E76K, heterozygous",
+  "developmentPublicationDOI": "",
+  "usagePublicationDOIs": ["10.3389/fonc.2023.1052930"],
+  "itemAcquisition": ""
+}


### PR DESCRIPTION
## New term: Ptpn11E76K/+ (Shp2E76K/+) murine JMML model

### Why

Identified while curating NF portal dataset **syn74607259** (GEO GSE211278, PMID 36739480): *Potential clinical use of azacitidine and MEK inhibitor combination therapy in PTPN11-mutated juvenile myelomonocytic leukemia.* The study uses a Shp2 E76K/+ murine JMML model, but `Ptpn11E76K/+` was absent from the `AnimalModel` and `AnimalModelManual` controlled vocabularies. Files had to be annotated with a free-text `modelSystemName` value pending this registry addition.

### Model summary

| Field | Value |
|-------|-------|
| Name | Ptpn11E76K/+ |
| Synonyms | Shp2E76K/+, Shp2 E76K/+, SHP2 E76K/+ |
| Species | Mus musculus |
| Allele type | Knock-in (heterozygous) |
| Affected gene | Ptpn11 (encodes SHP2) |
| Disease | Juvenile myelomonocytic leukemia (JMML) |
| Mechanism | Gain-of-function E76K mutation hyperactivates Ras/MAPK |
| Background | C57BL/6 |

### Additional models identified (for follow-up PRs)

Two additional model systems were used in NF portal datasets this week without controlled vocabulary entries:

1. **JW23.3 / JW23.4** — Mouse MPNST xenograft-derived cell lines (used in syn74319292). These are currently annotated as free-text `modelSystemName`. Would fit in `submissions/cell_lines/` — needs separate PR.

2. **Human UCB CD34+ NF1 KO** — Human cord blood CD34+ HSPCs with CRISPR NF1 knockout (PMID 32777070, syn74607347). Used to model JMML. Would fit in `submissions/patient_derived_models/` or a new "in vitro model" category — needs team discussion on categorization.