### PR TITLE
Add hSC2λ-shNF2 NF2-deficient human Schwann cell line

### DIFF
--- a/submissions/animal_models/Ptpn11_E76K_het_JMML.json
+++ b/submissions/animal_models/Ptpn11_E76K_het_JMML.json
@@ -1,0 +1,37 @@
+{
+  "_source": "manual_curation",
+  "_publications": [
+    {
+      "_pmid": "PMID:36739480",
+      "_doi": "10.3389/fonc.2023.1052930",
+      "_publicationTitle": "Potential clinical use of azacitidine and MEK inhibitor combination therapy in PTPN11-mutated juvenile myelomonocytic leukemia",
+      "_year": "2023",
+      "_usageType": "Experimental Usage",
+      "_context": "Shp2 E76K/+ murine model used to evaluate azacitidine + PD-901 (MEK inhibitor) combination therapy for PTPN11-mutated JMML. RNA-seq data deposited in GEO GSE211278 (Synapse syn74607259)."
+    }
+  ],
+  "_confidence": "0.9",
+  "_verdict": "Accept",
+  "toolType": "animal_model",
+  "userInfo": {},
+  "basicInfo": {
+    "animalModelName": "Ptpn11E76K/+",
+    "description": "Heterozygous Ptpn11 E76K germline knock-in mouse model of juvenile myelomonocytic leukemia (JMML). Encodes a gain-of-function SHP2 E76K variant that hyperactivates the Ras/MAPK pathway, recapitulating PTPN11-mutated JMML.",
+    "synonyms": "Shp2E76K/+; Ptpn11E76K/+; SHP2 E76K/+",
+    "species": "Mouse"
+  },
+  "strainNomenclature": "Ptpn11E76K/+",
+  "backgroundStrain": "C57BL/6",
+  "backgroundSubstrain": "",
+  "animalModelDisease": "Juvenile myelomonocytic leukemia",
+  "animalModelManifestation": "JMML",
+  "transplantationType": "",
+  "animalState": "",
+  "generation": "",
+  "alleleType": "Knock-in",
+  "affectedGeneSymbol": "Ptpn11",
+  "mutationTypes": "Gain-of-function point mutation E76K, heterozygous",
+  "developmentPublicationDOI": "",
+  "usagePublicationDOIs": ["10.3389/fonc.2023.1052930"],
+  "itemAcquisition": ""
+}

--- a/submissions/cell_lines/hSC2lambda_shNF2.json
+++ b/submissions/cell_lines/hSC2lambda_shNF2.json
@@ -1,0 +1,42 @@
+{
+  "_source": "manual_curation",
+  "_publications": [
+    {
+      "_pmid": "PMID:35855490",
+      "_doi": "10.3390/cancers14143373",
+      "_publicationTitle": "Validation of Bromodomain and Extraterminal Proteins as Therapeutic Targets in Neurofibromatosis Type 2",
+      "_year": "2022",
+      "_usageType": "Experimental Usage",
+      "_context": "BRD4 ChIP-seq performed in hSC2λ-shNF2 cells treated with DMSO or JQ1 (1 µM). 55,568 BRD4 ChIP peaks called in control cells; 436 JQ1-sensitive peaks identified. ChIP-seq data deposited in GEO GSE167560 (Synapse syn74315329)."
+    }
+  ],
+  "_confidence": "0.85",
+  "_verdict": "Accept",
+  "toolType": "cell_line",
+  "userInfo": {},
+  "basicInfo": {
+    "cellLineName": "hSC2λ-shNF2",
+    "synonyms": "HSC7228-shNF2; hSC2λ NF2-shRNA",
+    "description": "Human Schwann cell line (HSC7228 background) with stable lentiviral NF2-shRNA knockdown (shRNA #75, Sigma-Mission), generating an NF2/merlin-deficient model for NF2-related schwannomatosis research.",
+    "species": "Human",
+    "sex": "Unknown",
+    "developerName": "",
+    "developerAffiliation": "University of Central Florida"
+  },
+  "cellLineCategory": "Engineered cell line",
+  "organ": "Peripheral Nervous System",
+  "cellLineGeneticDisorder": "Neurofibromatosis Type 2",
+  "cellLineManifestation": "Schwannoma",
+  "tissue": "Schwann cell",
+  "cultureMedia": "",
+  "resistance": "",
+  "originYear": "",
+  "strProfile": "",
+  "pkpdCapabilities": "",
+  "mechanismOfActionValidation": "",
+  "pediatricSuitability": "",
+  "timelineToResults": "",
+  "developmentPublicationDOI": "",
+  "usagePublicationDOIs": ["10.3390/cancers14143373"],
+  "itemAcquisition": ""
+}


### PR DESCRIPTION
## New term: hSC2λ-shNF2

NF2/merlin-deficient human Schwann cell line used for BRD4 ChIP-seq in PMID 35855490.

| Field | Value |
|-------|-------|
| Name | hSC2λ-shNF2 |
| Synonyms | HSC7228-shNF2 |
| Background | HSC7228 human Schwann cell line |
| Engineering | Stable lentiviral NF2-shRNA knockdown (#75, Sigma-Mission) |
| Species | Human |
| Disorder | NF2-related schwannomatosis |
| Used in | GEO GSE167560, Synapse syn74315329 (PMID 35855490) |

Currently annotated as free-text `modelSystemName` in Synapse pending this vocabulary addition.