### PR TITLE
Add MCF7 cell line

### DIFF
--- a/submissions/cell_lines/MCF7.json
+++ b/submissions/cell_lines/MCF7.json
@@ -1,0 +1,42 @@
+{
+  "_source": "manual_curation",
+  "_publications": [
+    {
+      "_pmid": "PMID:40864686",
+      "_doi": "10.1126/scitranslmed.adq5492",
+      "_publicationTitle": "NF1-depleted ER+ breast cancers are differentially sensitive to CDK4-6 inhibitors",
+      "_year": "2025",
+      "_usageType": "Experimental Usage",
+      "_context": "MCF-7 (ATCC HTB-22) parental line engineered with a doxycycline-inducible NF1 shRNA knockdown; used for ER ChIP-seq (+/- DOX, +/- estradiol) to study somatic NF1 loss and CDK4/6 inhibitor sensitivity in ER+ breast cancer. GEO GSE273881 / ENA PRJNA1143539 (Synapse syn74318610)."
+    }
+  ],
+  "_confidence": "0.9",
+  "_verdict": "Accept",
+  "toolType": "cell_line",
+  "userInfo": {},
+  "basicInfo": {
+    "cellLineName": "MCF-7",
+    "synonyms": "MCF7",
+    "description": "Human ER+ breast adenocarcinoma cell line (ATCC HTB-22) with a doxycycline-inducible NF1 shRNA knockdown, used to model somatic NF1 loss in ER+ breast cancer and its effect on CDK4/6 inhibitor sensitivity. Not a germline NF1 disease model.",
+    "species": "Human",
+    "sex": "Female",
+    "developerName": "",
+    "developerAffiliation": ""
+  },
+  "cellLineCategory": "Cancer cell line",
+  "organ": "Breast",
+  "cellLineGeneticDisorder": "None",
+  "cellLineManifestation": "Invasive Breast Carcinoma",
+  "tissue": "Unspecified",
+  "cultureMedia": "",
+  "resistance": "",
+  "originYear": "",
+  "strProfile": "",
+  "pkpdCapabilities": [],
+  "mechanismOfActionValidation": ["CDK inhibitors"],
+  "pediatricSuitability": "Adult",
+  "timelineToResults": "",
+  "developmentPublicationDOI": "",
+  "usagePublicationDOIs": ["10.1126/scitranslmed.adq5492"],
+  "itemAcquisition": "Purchase from Vendor"
+}

--- a/submissions/cell_lines/MCF7.json
+++ b/submissions/cell_lines/MCF7.json
@@ -38,5 +38,8 @@
   "timelineToResults": "",
   "developmentPublicationDOI": "",
   "usagePublicationDOIs": ["10.1126/scitranslmed.adq5492"],
-  "itemAcquisition": "Purchase from Vendor"
+  "itemAcquisition": "Purchase from Vendor",
+  "vendor": "ATCC",
+  "catalogNumber": "HTB-22",
+  "catalogURL": "https://www.atcc.org/products/htb-22"
 }


### PR DESCRIPTION
MCF-7 (ATCC HTB-22) with a doxycycline-inducible NF1 shRNA knockdown, used in a ChIP-seq study of somatic NF1 loss in ER+ breast cancer (PMID 40864686, nadia#177). Per nf-metadata-dictionary#868, which already added MCF-7 to the `CellLineModelManual` annotation vocabulary for file-level metadata (a separate registry from this one).

Not a germline NF1 model — `cellLineGeneticDisorder` is set to `"None"` accordingly; `cellLineManifestation` uses `"Invasive Breast Carcinoma"` for the parental line's own tumor type.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)