### PR TITLE
Add NRG mice (JAX #007799)

### DIFF
--- a/submissions/animal_models/NRG.json
+++ b/submissions/animal_models/NRG.json
@@ -1,0 +1,38 @@
+{
+  "_source": "manual_curation",
+  "_curationNote": "No development publication DOI/PMID could be confidently verified for this strain (JAX's strain page is JS-rendered and didn't return one via fetch); left blank rather than guessed. JAX stock #007799: https://www.jax.org/strain/007799",
+  "_publications": [
+    {
+      "_pmid": "",
+      "_doi": "",
+      "_publicationTitle": "",
+      "_year": "",
+      "_usageType": "Experimental Usage",
+      "_context": "NRG mice used as immunodeficient xenograft hosts for NF1;Ink4a MPNST tumor models (JH002 human MPNST xenografts) in Steven Rhodes' group (Indiana University), per Jira NFOSI-308 / Synapse syn25999248. Requested as a modelSystemName vocabulary addition in nf-metadata-dictionary#205."
+    }
+  ],
+  "_confidence": "0.9",
+  "_verdict": "Accept",
+  "toolType": "animal_model",
+  "userInfo": {},
+  "basicInfo": {
+    "animalModelName": "NRG",
+    "description": "Extremely immunodeficient mouse strain (Rag1 and Il2rg double null) used as a xenograft recipient; carries no disease phenotype of its own but is the standard host strain for engrafting human NF1-associated tumor cells (e.g. MPNST xenografts).",
+    "synonyms": "NOD.Cg-Rag1tm1Mom Il2rgtm1Wjl/SzJ; NOD-Rag1null IL2rgnull; NOD rag gamma; NOD-RG; JAX stock #007799",
+    "species": "Mouse"
+  },
+  "strainNomenclature": "NOD.Cg-Rag1tm1Mom Il2rgtm1Wjl/SzJ",
+  "backgroundStrain": "NOD",
+  "backgroundSubstrain": "",
+  "animalModelGeneticDisorder": "No known disease",
+  "animalModelOfManifestation": "No Symptoms",
+  "transplantationType": "Xenograft",
+  "animalState": "",
+  "generation": "",
+  "alleleType": "Null/knockout",
+  "affectedGeneSymbol": "Rag1; Il2rg",
+  "mutationTypes": "Combined Rag1 and Il2rg null mutations (double knockout)",
+  "developmentPublicationDOI": "",
+  "usagePublicationDOIs": [],
+  "itemAcquisition": "Purchase from Vendor"
+}


### PR DESCRIPTION
NOD.Cg-Rag1tm1Mom Il2rgtm1Wjl/SzJ — extremely immunodeficient Rag1/Il2rg double-null mouse strain, used as the xenograft host for NF1-associated tumor models (e.g. MPNST xenografts) rather than carrying any NF-related phenotype itself. Context from Jira NFOSI-308 (Steven Rhodes' group, Indiana University; JH002 MPNST xenografts, Nf1;Ink4a tumor model). The `modelSystemName` vocabulary side of this was already handled in nf-metadata-dictionary#205.

No development publication DOI/PMID is included — I couldn't confidently verify one for this strain (JAX's strain page is JS-rendered and didn't return citation info via fetch), so left it blank rather than guessing; see `_curationNote` in the file.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)