### PR TITLE
Fix schema violations in Ptpn11 JMML / hSC2λ-shNF2, add NRG to hostStrain enum

### DIFF
--- a/NF-Tools-Schemas/patient-derived-model/submitPatientDerivedModel.json
+++ b/NF-Tools-Schemas/patient-derived-model/submitPatientDerivedModel.json
@@ -37,6 +37,7 @@
           "title": "Host Strain (for xenografts)",
           "enum": [
             "NSG",
+            "NRG",
             "NOD-SCID",
             "nude",
             "SCID",

--- a/submissions/animal_models/Ptpn11_E76K_het_JMML.json
+++ b/submissions/animal_models/Ptpn11_E76K_het_JMML.json
@@ -12,6 +12,7 @@
   ],
   "_confidence": "0.9",
   "_verdict": "Accept",
+  "_curationNote": "animalModelGeneticDisorder is enum-constrained to NF1/NF2/Schwannomatosis/No known disease. This is a PTPN11-driven JMML model, not NF-related — none of those values are accurate, so 'No known disease' is used as the least-wrong option. animalModelOfManifestation uses 'Other' + animalModelOfManifestationOther for the same reason (no JMML-related enum value exists). Flagging for a curator/schema decision.",
   "toolType": "animal_model",
   "userInfo": {},
   "basicInfo": {
@@ -23,15 +24,16 @@
   "strainNomenclature": "Ptpn11E76K/+",
   "backgroundStrain": "C57BL/6",
   "backgroundSubstrain": "",
-  "animalModelGeneticDisorder": "Juvenile myelomonocytic leukemia",
-  "animalModelOfManifestation": "JMML",
+  "animalModelGeneticDisorder": "No known disease",
+  "animalModelOfManifestation": "Other",
+  "animalModelOfManifestationOther": "Juvenile myelomonocytic leukemia (JMML)",
   "transplantationType": "",
   "animalState": "",
   "generation": "",
-  "alleleType": "Knock-in",
+  "alleleType": "Constitutively active",
   "affectedGeneSymbol": "Ptpn11",
-  "mutationTypes": "Gain-of-function point mutation E76K, heterozygous",
+  "mutationTypes": {"Single point mutation": true, "Nucleotide substitutions": true},
   "developmentPublicationDOI": "",
   "usagePublicationDOIs": ["10.3389/fonc.2023.1052930"],
-  "itemAcquisition": ""
+  "itemAcquisition": "Contact Developer"
 }

--- a/submissions/cell_lines/hSC2lambda_shNF2.json
+++ b/submissions/cell_lines/hSC2lambda_shNF2.json
@@ -27,16 +27,16 @@
   "organ": "Peripheral Nervous System",
   "cellLineGeneticDisorder": "Neurofibromatosis Type 2",
   "cellLineManifestation": "Schwannoma",
-  "tissue": "Schwann cell",
+  "tissue": "Nerve Tissue",
   "cultureMedia": "",
   "resistance": "",
-  "originYear": "",
+  "originYear": 2022,
   "strProfile": "",
-  "pkpdCapabilities": "",
-  "mechanismOfActionValidation": "",
-  "pediatricSuitability": "",
+  "pkpdCapabilities": [],
+  "mechanismOfActionValidation": [],
+  "pediatricSuitability": "Unknown",
   "timelineToResults": "",
   "developmentPublicationDOI": "",
   "usagePublicationDOIs": ["10.3390/cancers14143373"],
-  "itemAcquisition": ""
+  "itemAcquisition": "Contact Developer"
 }


### PR DESCRIPTION
Found by running the new validator (companion PR) against the current submissions/ tree:

- **Ptpn11_E76K_het_JMML.json**: \`alleleType\` \`"Knock-in"\` wasn't a valid enum value (using \`"Constitutively active"\`, accurate for a GOF point mutation); \`mutationTypes\` was a string, schema expects an object of booleans; \`itemAcquisition\` was blank. \`animalModelGeneticDisorder\`/\`animalModelOfManifestation\` still don't have a good enum fit for a non-NF JMML model — used \`"No known disease"\` / \`"Other"\` + \`animalModelOfManifestationOther\`, flagged via \`_curationNote\` for a schema/curator decision.
- **hSC2lambda_shNF2.json**: \`tissue\` \`"Schwann cell"\` wasn't a valid enum value (using \`"Nerve Tissue"\`); \`pkpdCapabilities\`/\`mechanismOfActionValidation\` were empty strings instead of arrays; \`pediatricSuitability\` and \`itemAcquisition\` were blank; \`originYear\` was a blank string instead of an integer (set to 2022, the publication year).
- **patient-derived-model schema**: added \`"NRG"\` to the \`hostStrain\` enum — three existing PDX submissions (JH-2-055-b, JH-2-079-c, MN-2) already reference it as a host strain without it being valid, and it's the strain from #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)